### PR TITLE
Compile RPC proto to JavaScript

### DIFF
--- a/webconsole/common/protos.ts
+++ b/webconsole/common/protos.ts
@@ -15,6 +15,6 @@
 
 export async function createDefaultProtoCollection() {
   // @ts-ignore
-  const ProtoCollection = await import("pigweedjs/protos/collection.umd");
+  const ProtoCollection = await import("../protos/bundle");
   return new ProtoCollection.ProtoCollection();
 }

--- a/webconsole/package.json
+++ b/webconsole/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "proto": "cd .. && pw_protobuf_compiler -p pigweed/pw_rpc/echo.proto -p pigweed/pw_protobuf/pw_protobuf_protos/status.proto -p pigweed/pw_protobuf/pw_protobuf_protos/common.proto -p pigweed/pw_tokenizer/options.proto -p pigweed/pw_rpc/internal/packet.proto -p app/proto/demo.proto --out webconsole/protos && esbuild webconsole/protos/collection.js --bundle --sourcemap --format=esm --outfile=webconsole/protos/bundle.js",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"
@@ -27,6 +28,7 @@
     "pigweedjs": "latest",
     "react": "18.2.0",
     "react-chartjs-2": "^5.2.0",
+    "react-cookie-consent": "^8.0.1",
     "react-dom": "18.2.0",
     "react-virtualized": "^9.22.3",
     "react-virtualized-auto-sizer": "^1.0.6",
@@ -40,6 +42,7 @@
     "@types/react-dom": "18.0.6",
     "@types/react-virtualized": "^9.21.21",
     "@types/react-window": "^1.8.5",
+    "esbuild": "^0.17.19",
     "eslint": "8.21.0",
     "eslint-config-next": "12.2.3",
     "sass": "^1.54.0",


### PR DESCRIPTION
Run `npm run proto` to compile protos

To invoke streaming RPC: 

```
import {GetValueUpdate} from "../protos/app/proto/demo_pb"
...

const request = new GetValueUpdate();
...
device.client.channel(1).methodStub('rpc_demo.remoteconfig.RemoteConfig.GetValue').invoke(request, (response) => {
  console.log(response);
});
```